### PR TITLE
Use forward slashes for paths; sphinx prefers these and wasn't findin…

### DIFF
--- a/Cogs.Publishers/BuildSphinxDocumentation.cs
+++ b/Cogs.Publishers/BuildSphinxDocumentation.cs
@@ -265,7 +265,7 @@ namespace Cogs.Publishers
                 builder.AppendLine("   |stub|");
                 builder.AppendLine();
                 builder.Append(".. |stub| image:: ");
-                builder.AppendLine(Path.Combine("..", "..", "images", itemType.Name + ".svg"));
+                builder.AppendLine(Path.Combine("../../images/" + itemType.Name + ".svg"));
                 builder.AppendLine();
 
                 // Output Properties details


### PR DESCRIPTION
…g the images with the single backslash